### PR TITLE
Add PostgreSQL driver to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,17 @@
 # AI Dungeon Master CLI
 
-Esta aplicación proporciona una interfaz de línea de comandos que utiliza una Inteligencia Artificial para dirigir partidas de rol y mantener la coherencia de un mundo persistente.
+This repository contains a small command line tool that uses an AI model and a SQLAlchemy database to manage a role playing game world.
 
-## Requisitos
-- Python 3.10+
-- Dependencias indicadas en `requirements.txt` (si existe)
-- Una base de datos accesible vía SQLAlchemy (SQLite por defecto)
-- Clave de API de OpenAI para las funciones de IA (opcional pero recomendada)
+## Setup
 
-## Configuración
-1. Copia `.env.example` a `.env` y ajusta los valores necesarios:
-   ```
-   DATABASE_URL="postgresql://usuario:password@localhost/tu_db"
-   OPENAI_API_KEY="sk-tu_clave"
-   ```
-   Si `DATABASE_URL` no se define se usará `sqlite:///./default_dm_database.db`.
+1. **Create a virtual environment** for Python 3.10 or later and activate it.
+2. Run `pip install -r requirements.txt` to install the dependencies. This
+   includes the `psycopg2-binary` driver required for connecting to PostgreSQL
+   databases.
+3. Copy `.env.example` to `.env` and fill in the values for `DATABASE_URL` and `OPENAI_API_KEY`.
+4. Seed the database with `python populate_db.py`.
+5. Start the interactive CLI with `python main.py`.
 
-2. Instala las dependencias necesarias y ejecuta el script de población de datos:
-   ```bash
-   python populate_db.py
-   ```
-
-## Uso del CLI
-Lanza el programa principal:
-```bash
-python main.py
-```
-Dentro del CLI escribe `help` para ver los comandos disponibles. Podrás añadir personajes, registrar eventos y conversar con el DM.
-
-Los datos utilizados para poblar la base se encuentran en la carpeta `data/` en formato JSON para facilitar su modificación.
-
+If you plan to use PostgreSQL, make sure the PostgreSQL client libraries are
+installed on your system so that SQLAlchemy and `psycopg2-binary` can connect
+properly.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+sqlalchemy
+openai
+python-dotenv
+psycopg2-binary


### PR DESCRIPTION
## Summary
- mention psycopg2-binary in setup instructions
- add psycopg2-binary to requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
