### PR TITLE
Fix world state and ruleset field references

### DIFF
--- a/agent/dm_agent.py
+++ b/agent/dm_agent.py
@@ -481,12 +481,12 @@ class DmAgent:
 
             if world_state:
                 world_state.current_event = event_description
-                world_state.active_effects = active_effects
+                world_state.active_effects_json = active_effects
             else:
                 # If no world state exists, create a new one
                 world_state = WorldState(
                     current_event=event_description,
-                    active_effects=active_effects
+                    active_effects_json=active_effects
                 )
                 self.db_session.add(world_state)
             

--- a/engine/rules_engine.py
+++ b/engine/rules_engine.py
@@ -23,20 +23,20 @@ class RulesEngine:
             ruleset_name_origin = None
 
             for ruleset in all_rulesets:
-                if ruleset.rules is None:
+                if ruleset.rules_json is None:
                     continue # Skip if rules field is null
 
                 try:
                     # The 'rules' field in RuleSet model is expected to be JSON.
                     # SQLAlchemy's JSON type might automatically deserialize it to Python dict/list.
                     # If it's a string, json.loads() is needed.
-                    if isinstance(ruleset.rules, str):
-                        rules_data = json.loads(ruleset.rules)
+                    if isinstance(ruleset.rules_json, str):
+                        rules_data = json.loads(ruleset.rules_json)
                     else:
-                        rules_data = ruleset.rules # Assumed to be already parsed Python object by SQLAlchemy
+                        rules_data = ruleset.rules_json  # Assumed to be already parsed Python object by SQLAlchemy
                 
                 except json.JSONDecodeError as je:
-                    print(f"JSONDecodeError for ruleset '{ruleset.name}': {je}. Rules: '{ruleset.rules}'")
+                    print(f"JSONDecodeError for ruleset '{ruleset.name}': {je}. Rules: '{ruleset.rules_json}'")
                     continue # Skip this ruleset if JSON is malformed
 
                 if isinstance(rules_data, list):
@@ -94,7 +94,7 @@ class RulesEngine:
 #         {"keyword": "stealth", "description": "Roll Dexterity (Stealth) vs Perception.", "difficulty_class_info": "Varies by situation"},
 #         {"keyword": "persuade", "description": "Roll Charisma (Persuasion) vs Insight or fixed DC.", "difficulty_class_info": "DC 10 for simple, DC 20 for hard"}
 #     ])
-#     ruleset1 = RuleSet(name="Core Mechanics", rules=rules_list_json)
+#     ruleset1 = RuleSet(name="Core Mechanics", rules_json=rules_list_json)
 #     session.add(ruleset1)
 #
 #     # 2. Create and add a RuleSet with dictionary-based rules
@@ -102,7 +102,7 @@ class RulesEngine:
 #         "magic_missile": {"spell_level": 1, "damage": "3d4+3 force", "range": "120 feet", "description": "Automatically hits."},
 #         "fireball": {"spell_level": 3, "damage": "8d6 fire", "range": "150 feet", "radius": "20 feet", "save_type": "Dexterity for half"}
 #     })
-#     ruleset2 = RuleSet(name="Spell Rules", rules=rules_dict_json)
+#     ruleset2 = RuleSet(name="Spell Rules", rules_json=rules_dict_json)
 #     session.add(ruleset2)
 #     
 #     session.commit()

--- a/main.py
+++ b/main.py
@@ -220,7 +220,7 @@ def main():
                     
                     world_state = agent.update_world_state(event_desc_str, active_effects)
                     if world_state:
-                        print(f"World state updated: Event - '{world_state.current_event}', Effects - {world_state.active_effects}")
+                        print(f"World state updated: Event - '{world_state.current_event}', Effects - {world_state.active_effects_json}")
                     else:
                         print("Failed to update world state.")
                 except json.JSONDecodeError as je:


### PR DESCRIPTION
## Summary
- update DmAgent to use `active_effects_json`
- display world state using the new field
- update RulesEngine for `rules_json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b48645854832ca17e12c7504ccfc4

## Resumen por Sourcery

Corrige las referencias de campos para usar `active_effects_json` para los efectos del estado mundial y `rules_json` para los conjuntos de reglas.

Correcciones de errores:
- Actualiza RulesEngine para hacer referencia a `rules_json` en lugar del campo obsoleto `rules`.
- Actualiza el agente DM y la aplicación principal para usar `active_effects_json` al actualizar y mostrar el estado mundial.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix field references to use `active_effects_json` for world state effects and `rules_json` for rulesets

Bug Fixes:
- Update RulesEngine to reference `rules_json` instead of the deprecated `rules` field
- Update DM agent and main application to use `active_effects_json` when updating and displaying world state

</details>