### PR TITLE
Improve DM context gathering

### DIFF
--- a/engine/rules_engine.py
+++ b/engine/rules_engine.py
@@ -23,20 +23,20 @@ class RulesEngine:
             ruleset_name_origin = None
 
             for ruleset in all_rulesets:
-                if ruleset.rules is None:
+                if ruleset.rules_json is None:
                     continue # Skip if rules field is null
 
                 try:
                     # The 'rules' field in RuleSet model is expected to be JSON.
                     # SQLAlchemy's JSON type might automatically deserialize it to Python dict/list.
                     # If it's a string, json.loads() is needed.
-                    if isinstance(ruleset.rules, str):
-                        rules_data = json.loads(ruleset.rules)
+                    if isinstance(ruleset.rules_json, str):
+                        rules_data = json.loads(ruleset.rules_json)
                     else:
-                        rules_data = ruleset.rules # Assumed to be already parsed Python object by SQLAlchemy
+                        rules_data = ruleset.rules_json  # Assumed to be already parsed Python object by SQLAlchemy
                 
                 except json.JSONDecodeError as je:
-                    print(f"JSONDecodeError for ruleset '{ruleset.name}': {je}. Rules: '{ruleset.rules}'")
+                    print(f"JSONDecodeError for ruleset '{ruleset.name}': {je}. Rules: '{ruleset.rules_json}'")
                     continue # Skip this ruleset if JSON is malformed
 
                 if isinstance(rules_data, list):
@@ -94,7 +94,7 @@ class RulesEngine:
 #         {"keyword": "stealth", "description": "Roll Dexterity (Stealth) vs Perception.", "difficulty_class_info": "Varies by situation"},
 #         {"keyword": "persuade", "description": "Roll Charisma (Persuasion) vs Insight or fixed DC.", "difficulty_class_info": "DC 10 for simple, DC 20 for hard"}
 #     ])
-#     ruleset1 = RuleSet(name="Core Mechanics", rules=rules_list_json)
+#     ruleset1 = RuleSet(name="Core Mechanics", rules_json=rules_list_json)
 #     session.add(ruleset1)
 #
 #     # 2. Create and add a RuleSet with dictionary-based rules
@@ -102,7 +102,7 @@ class RulesEngine:
 #         "magic_missile": {"spell_level": 1, "damage": "3d4+3 force", "range": "120 feet", "description": "Automatically hits."},
 #         "fireball": {"spell_level": 3, "damage": "8d6 fire", "range": "150 feet", "radius": "20 feet", "save_type": "Dexterity for half"}
 #     })
-#     ruleset2 = RuleSet(name="Spell Rules", rules=rules_dict_json)
+#     ruleset2 = RuleSet(name="Spell Rules", rules_json=rules_dict_json)
 #     session.add(ruleset2)
 #     
 #     session.commit()

--- a/main.py
+++ b/main.py
@@ -220,7 +220,7 @@ def main():
                     
                     world_state = agent.update_world_state(event_desc_str, active_effects)
                     if world_state:
-                        print(f"World state updated: Event - '{world_state.current_event}', Effects - {world_state.active_effects}")
+                        print(f"World state updated: Event - '{world_state.current_event}', Effects - {world_state.active_effects_json}")
                     else:
                         print("Failed to update world state.")
                 except json.JSONDecodeError as je:


### PR DESCRIPTION
## Summary
- add world state and NPC helpers to `DmAgent`
- extend `process_input` to include world state and NPC context

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683b48645854832ca17e12c7504ccfc4

## Resumen por Sourcery

Añade el estado del mundo y la recopilación del contexto de los NPC al agente DM y estandariza los nombres de los campos JSON en todos los modelos y la lógica de procesamiento.

Nuevas características:
- Añade los métodos `get_world_state`, `get_all_npcs` y `get_npc_info_for_prompt` al agente DM
- Extiende `process_input` para añadir los detalles del estado del mundo, los efectos activos y la información de los NPC detectados al contexto

Mejoras:
- Renombra `WorldState.active_effects` a `active_effects_json` y `RuleSet.rules` a `rules_json`
- Actualiza `rules_engine` y `main.py` para hacer referencia a los nuevos nombres de los campos JSON

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add world state and NPC context gathering to the DM agent and standardize JSON field names across models and processing logic.

New Features:
- Add get_world_state, get_all_npcs, and get_npc_info_for_prompt methods to the DM agent
- Extend process_input to append world state details, active effects, and detected NPC info to the context

Enhancements:
- Rename WorldState.active_effects to active_effects_json and RuleSet.rules to rules_json
- Update rules_engine and main.py to reference the new JSON field names

</details>